### PR TITLE
Incomplete logs

### DIFF
--- a/ui/src/components/EventsTable.vue
+++ b/ui/src/components/EventsTable.vue
@@ -23,13 +23,13 @@ const columns: QTableColumn[]  = [
   },
   {
     name: 'changed_from',
-    field: 'changed_from',
+    field: 'old_value',
     label: t('LABEL_CHANGED_FROM'),
     align: 'left',
   },
   {
     name: 'changed_to',
-    field: 'changed_to',
+    field: 'new_value',
     label: t('LABEL_CHANGED_TO'),
     align: 'left',
   },

--- a/ui/src/components/ReportLogsTable.vue
+++ b/ui/src/components/ReportLogsTable.vue
@@ -36,7 +36,7 @@ const columns: QTableColumn[] = [
   },
   {
     name: 'location',
-    field: (row) => (row.location ? ` ${row.location}:${row.line}` : ''),
+    field: (row) => (row.file ? `${row.file}:${row.line}` : ''),
     label: t('LABEL_LOCATION_SHORT'),
     align: 'left',
   },

--- a/ui/src/components/ReportLogsTable.vue
+++ b/ui/src/components/ReportLogsTable.vue
@@ -26,7 +26,10 @@ const columns: QTableColumn[] = [
   },
   {
     name: 'message',
-    field: 'message',
+    field: (row) =>
+      row.source?.startsWith('/')
+        ? `${row.source}: ${row.message}`
+        : row.message,
     label: t('LABEL_MESSAGE'),
     align: 'left',
     style: 'white-space: pre;',


### PR DESCRIPTION
The message field for the Notice log resource currently only contains the result, and the 'location' column is empty.
Additionally, the 'changed from' and 'changed to' columns for events are empty.

This PR adds the missing data to these fields.

Before:
<img width="1542" height="426" alt="Screenshot_20260312_192845" src="https://github.com/user-attachments/assets/006e24a0-2c55-4f2f-91f9-82a129ae12be" />

After:
<img width="1533" height="426" alt="Screenshot_20260312_195751" src="https://github.com/user-attachments/assets/d2bbe7a2-e36b-4a2f-b0c5-9578a99f5e80" />