### PR TITLE
consistent status column layout in reports table

### DIFF
--- a/ui/src/components/EventCountBlock.vue
+++ b/ui/src/components/EventCountBlock.vue
@@ -8,7 +8,7 @@ const eventCount = defineModel('event_count', {
 </script>
 
 <template>
-  <div class="row">
+  <div class="row no-wrap">
     <div class="col q-mr-sm event bg-negative rounded-borders text-center content-center">
       {{ eventCount.failures }}
       <q-tooltip>{{ $t('LABEL_FAILURE', 2) }}</q-tooltip>

--- a/ui/src/components/ReportStatus.vue
+++ b/ui/src/components/ReportStatus.vue
@@ -11,7 +11,7 @@ const report = defineModel('report', {
 </script>
 
 <template>
-  <div class="row">
+  <div class="row no-wrap">
     <StatusButton
       class="col-auto q-mr-sm"
       :status="report.status"

--- a/ui/src/components/ReportStatus.vue
+++ b/ui/src/components/ReportStatus.vue
@@ -19,20 +19,17 @@ const report = defineModel('report', {
       :certname="report.certname"
     />
     <div
-      class="q-mr-sm event bg-grey-7 rounded-borders text-center content-center"
+      class="col event bg-grey-7 rounded-borders text-center content-center"
     >
       {{ report.getMetricsValue('resources', 'total') }}
       <q-tooltip>{{ $t('LABEL_RESOURCE', 2) }}</q-tooltip>
     </div>
   </div>
-  <div class="row q-mt-sm">
-    <EventCountBlock :event_count="report.getEventCounts()" />
-  </div>
+  <EventCountBlock class="q-mt-sm" :event_count="report.getEventCounts()" />
 </template>
 
 <style scoped>
 .event {
   min-width: 32px;
-  text-align: center;
 }
 </style>

--- a/ui/src/components/StatusButton.vue
+++ b/ui/src/components/StatusButton.vue
@@ -27,6 +27,7 @@ function getStatusColor(status: string) {
 
 <style scoped>
 .status-btn {
+  min-width: 9em;
   max-width: 15em;
 }
 </style>


### PR DESCRIPTION
Status buttons had inconsistent widths (min-width: 9em fixes "changed" being narrower than "unchanged")

Resources count box was missing col, causing the two rows in each status cell to be different widths.

Removed redundant row wrapper around EventCountBlock

Removed duplicate text-align: center

Before:
<img width="503" height="632" alt="Screenshot_20260312_205959" src="https://github.com/user-attachments/assets/cfafd412-aab4-412a-a277-9241ab0db078" />

After:
<img width="497" height="620" alt="Screenshot_20260312_210033" src="https://github.com/user-attachments/assets/4f5a3bc6-27ca-48e8-b170-ce3954f742df" />
