### PR TITLE
Auto-load config.yaml from current directory by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var configPath = flag.String("config", "config.yml", "path to the config file ")
+var configPath = flag.String("config", "", "path to the config file")
 var printVersion = flag.Bool("version", false, "prints version")
 
 func init() {
@@ -71,7 +71,7 @@ func GetConfig() (*Config, error) {
 		viper.SetConfigType("yaml")
 		viper.AddConfigPath(".")
 
-		if configPath != nil {
+		if *configPath != "" {
 			log.Printf("Using config: %s", *configPath)
 			viper.SetConfigFile(*configPath)
 		}


### PR DESCRIPTION
Previously, the `-config` flag defaulted to "config.yml", causing `viper.SetConfigFile()` to always be called even when no flag was passed. This bypassed viper's name-based search and meant the documented behaviour of automatically loading `config.yaml` did not work.

With an empty default, viper falls through to its `SetConfigName` / `AddConfigPath` search, which finds `config.yaml` or `config.yml` in the current directory automatically, matching the documentation.