### PR TITLE
improve look of report view

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -20,6 +20,7 @@ but you can pass the -config parameter to define the location of the config file
 | queries                   |                           |           | array  | predefined queries (see query table)                 |
 | views                     |                           |           | array  | predefined views (see view table)                    |
 | trusted_proxies           | TRUSTED_PROXIES           |           | array  | List of trusted proxies (env var is space seperated) |
+| strip_path_prefix         | STRIP_PATH_PREFIX         |           | string | Strip base paths from Puppet code locations          |
 | puppetca.host             | PUPPETCA_HOST             |           | string | Address of Puppet CA server (optional)               |
 | puppetca.port             | PUPPETCA_PORT             | 8140      | int    | Port of Puppet CA server                             |
 | puppetca.tls              | PUPPETCA_TLS              | true      | bool   | Use TLS for Puppet CA communications                 |

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	PqlQueries      []ConfigPqlQuery `mapstructure:"queries"`
 	Views           []model.View     `mapstructure:"views"`
 	UnreportedHours uint64           `mapstructure:"unreported_hours"`
+	StripPathPrefix string           `mapstructure:"strip_path_prefix"`
 	PuppetCA        struct {
 		Host            string `mapstructure:"host"`
 		Port            uint64 `mapstructure:"port"`
@@ -81,6 +82,7 @@ func GetConfig() (*Config, error) {
 		viper.SetDefault("puppetdb.port", 8080)
 		viper.SetDefault("puppetdb.tls_ignore", false)
 		viper.SetDefault("unreported_hours", 3)
+		viper.SetDefault("strip_path_prefix", `/etc/puppetlabs/code/environments(/.*?/modules)?`)
 		viper.SetDefault("puppetca.port", 8140)
 		viper.SetDefault("puppetca.tls", true)
 		viper.SetDefault("puppetca.tls_ignore", false)
@@ -100,6 +102,7 @@ func GetConfig() (*Config, error) {
 		viper.BindEnv("puppetdb.tls_key", "PUPPETDB_TLS_KEY")
 		viper.BindEnv("puppetdb.tls_cert", "PUPPETDB_TLS_CERT")
 		viper.BindEnv("unreported_hours", "UNREPORTED_HOURS")
+		viper.BindEnv("strip_path_prefix", "STRIP_PATH_PREFIX")
 		viper.BindEnv("puppetca.host", "PUPPETCA_HOST")
 		viper.BindEnv("puppetca.port", "PUPPETCA_PORT")
 		viper.BindEnv("puppetca.tls", "PUPPETCA_TLS")

--- a/main.go
+++ b/main.go
@@ -64,12 +64,14 @@ func main() {
 				CaEnabled       bool
 				CaReadOnly      bool
 				UnreportedHours uint64
+				StripPathPrefix string
 			}
 
 			response := metaResponse{
 				CaEnabled:       caEnabled,
 				CaReadOnly:      cfg.PuppetCA.ReadOnly,
 				UnreportedHours: cfg.UnreportedHours,
+				StripPathPrefix: cfg.StripPathPrefix,
 			}
 
 			c.JSON(http.StatusOK, handler.NewSuccessResponse(response))

--- a/ui/src/client/models.ts
+++ b/ui/src/client/models.ts
@@ -10,6 +10,7 @@ export interface ApiMeta {
   CaEnabled: boolean
   CaReadOnly: boolean
   UnreportedHours: number
+  StripPathPrefix: string
 }
 
 export interface ApiVersion {

--- a/ui/src/components/ReportLogsTable.vue
+++ b/ui/src/components/ReportLogsTable.vue
@@ -3,6 +3,7 @@ import { type PuppetReportLog } from 'src/puppet/models/puppet-report';
 import { type QTableColumn } from 'quasar';
 import { useI18n } from 'vue-i18n';
 import { emptyPagination } from 'src/helper/objects';
+import { ref, computed } from 'vue';
 
 const { t } = useI18n();
 const logs = defineModel('logs', {
@@ -11,7 +12,18 @@ const logs = defineModel('logs', {
 });
 const flat = defineModel('flat', { type: Boolean, default: false });
 
-const columns: QTableColumn[] = [
+const props = defineProps<{
+  stripPathPrefix?: string | undefined;
+}>();
+
+const wrapMessages = ref(true);
+
+function shortenLocation(file: string): string {
+  if (!props.stripPathPrefix) return file;
+  return file.replace(new RegExp(props.stripPathPrefix), '…');
+}
+
+const columns = computed<QTableColumn[]>(() => [
   {
     name: 'timestamp',
     field: 'time',
@@ -32,15 +44,14 @@ const columns: QTableColumn[] = [
         : row.message,
     label: t('LABEL_MESSAGE'),
     align: 'left',
-    style: 'white-space: pre;',
   },
   {
     name: 'location',
-    field: (row) => (row.file ? `${row.file}:${row.line}` : ''),
+    field: (row) => (row.file ? `${shortenLocation(row.file)}:${row.line}` : ''),
     label: t('LABEL_LOCATION_SHORT'),
     align: 'left',
   },
-];
+]);
 </script>
 
 <template>
@@ -52,12 +63,30 @@ const columns: QTableColumn[] = [
     hide-pagination
     dense
   >
+    <template v-slot:header-cell-message="props">
+      <q-th :props="props" class="row no-wrap items-center">
+        <span>{{ props.col.label }}</span>
+        <q-space />
+        <q-btn
+          :icon="wrapMessages ? 'wrap_text' : 'notes'"
+          flat
+          round
+          dense
+          size="sm"
+          @click.stop="wrapMessages = !wrapMessages"
+        >
+          <q-tooltip>{{ wrapMessages ? 'Wrap: on' : 'Wrap: off' }}</q-tooltip>
+        </q-btn>
+      </q-th>
+    </template>
     <template v-slot:body="props">
       <q-tr :props="props">
         <q-td v-for="col in props.cols" :key="col.name" :props="props">
           <div v-if="col.name == 'level'">
-            <q-chip :color="props.row.color">{{ col.value }}</q-chip>
+            <q-chip :color="props.row.color" class="level-chip">{{ col.value }}</q-chip>
           </div>
+          <div v-else-if="col.name == 'message'" class="message-text" :class="wrapMessages ? 'wrap' : 'nowrap'">{{ col.value }}</div>
+          <div v-else-if="col.name == 'location'" class="location-text">{{ col.value }}</div>
           <div v-else>{{ col.value }}</div>
         </q-td>
       </q-tr>
@@ -65,4 +94,20 @@ const columns: QTableColumn[] = [
   </q-table>
 </template>
 
-<style scoped></style>
+<style scoped>
+.level-chip {
+  width: 4.5rem;
+}
+.level-chip :deep(.q-chip__content) {
+  justify-content: center;
+}
+.message-text, .location-text {
+  font-family: Consolas, Menlo, Courier, monospace;
+}
+.message-text.wrap {
+  white-space: pre-wrap;
+}
+.message-text.nowrap {
+  white-space: pre;
+}
+</style>

--- a/ui/src/pages/report/ReportDetailPage.vue
+++ b/ui/src/pages/report/ReportDetailPage.vue
@@ -4,6 +4,7 @@ import PqlQuery, { PqlEntity } from 'src/puppet/query-builder';
 import { computed, onMounted, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import Backend from 'src/client/backend';
+import { type ApiMeta } from 'src/client/models';
 import { type ApiPuppetReport, PuppetReport } from 'src/puppet/models/puppet-report';
 import { type ApiPuppetEvent, PuppetEvent } from 'src/puppet/models/puppet-event';
 import EventsTable from 'components/EventsTable.vue';
@@ -13,6 +14,7 @@ import MetricsTable from 'components/MetricsTable.vue';
 const route = useRoute();
 const report = ref<PuppetReport>();
 const events = ref<PuppetEvent[]>();
+const meta = ref<ApiMeta>();
 
 const report_hash = computed(() => {
   return route.params.report_hash;
@@ -58,6 +60,11 @@ function loadEvents() {
 onMounted(() => {
   loadReport();
   loadEvents();
+  void Backend.getMeta().then((result) => {
+    if (result.status === 200) {
+      meta.value = result.data.Data;
+    }
+  });
 });
 </script>
 
@@ -77,7 +84,7 @@ onMounted(() => {
         {{ $t('LABEL_LOG', 2) }}
       </q-card-section>
       <q-card-section class="q-pa-none">
-        <ReportLogsTable :logs="report.logsMapped" flat />
+        <ReportLogsTable :logs="report.logsMapped" :strip-path-prefix="meta?.StripPathPrefix" flat />
       </q-card-section>
     </q-card>
 


### PR DESCRIPTION
- used the same font-family as the facts box on the nodes overview for message and location column.

- added a toggle button in the message column header to wrap text inside the rows.

- the location column now uses short path instead of the full, configurable via STRIP_PATH_PREFIX.

- aligned chip's in the level column.

Before:
<img width="1120" height="480" alt="image" src="https://github.com/user-attachments/assets/330ccfa2-1238-46ea-97f9-45d1053bd0fe" />

After:
<img width="1163" height="484" alt="image" src="https://github.com/user-attachments/assets/76aa6b77-3d7f-4f3b-8198-de6ade15f8ef" />
