### PR TITLE
model: accept both ISO 8601 and named-timezone date formats from Puppet

### DIFF
--- a/model/ca.go
+++ b/model/ca.go
@@ -70,8 +70,40 @@ func UniqueCertificateStates(states []CertificateState) []CertificateState {
 	return result
 }
 
-type PuppetCaTime struct {
+// PuppetTime wraps time.Time with JSON parsing that accepts both RFC 3339 / ISO 8601
+// (used by the golang-puppet-ca implementation and expected by future implementations)
+// and the named-timezone format (e.g. "2006-01-02T15:04:05UTC") used by the Clojure-based
+// OpenVox Server, Puppet Server, OpenVoxDB, and PuppetDB implementations.
+type PuppetTime struct {
 	time.Time
+}
+
+// PuppetCaTime is an alias kept for backwards compatibility.
+type PuppetCaTime = PuppetTime
+
+// PuppetSerialNumber holds a certificate serial number that may arrive as either
+// a JSON number (OpenVox Server / Puppet Server) or a JSON string (golang-puppet-ca
+// and expected future implementations). It always marshals back as a JSON string.
+type PuppetSerialNumber struct {
+	val string
+}
+
+func (s *PuppetSerialNumber) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		s.val = str
+		return nil
+	}
+	var n json.Number
+	if err := json.Unmarshal(data, &n); err != nil {
+		return fmt.Errorf("cannot parse %s as a serial number: %w", data, err)
+	}
+	s.val = n.String()
+	return nil
+}
+
+func (s PuppetSerialNumber) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.val)
 }
 
 type CertificateStatus struct {
@@ -81,9 +113,9 @@ type CertificateStatus struct {
 	Fingerprints map[string]string `json:"fingerprints"`
 	DnsAltNames  []string          `json:"dns_alt_names"`
 
-	SubjectAltNames         *[]string          `json:"subject_alt_names,omitempty"`
-	SerialNumber            *int               `json:"serial_number,omitempty"`
-	AuthorizationExtensions *map[string]string `json:"authorization_extensions,omitempty"`
+	SubjectAltNames         *[]string              `json:"subject_alt_names,omitempty"`
+	SerialNumber            *PuppetSerialNumber    `json:"serial_number,omitempty"`
+	AuthorizationExtensions *map[string]string     `json:"authorization_extensions,omitempty"`
 	NotBefore               *PuppetCaTime      `json:"not_before,omitempty"`
 	NotAfter                *PuppetCaTime      `json:"not_after,omitempty"`
 }
@@ -97,25 +129,32 @@ type CertificateStatusResponse struct {
 	CertificateStatuses []CertificateStatus `json:"certificate_statuses"`
 }
 
+// puppetCaTimeLayout is the non-standard format used by OpenVox Server, Puppet Server,
+// OpenVoxDB, and PuppetDB (Clojure implementations), which emit a named timezone
+// abbreviation (e.g. "UTC", "EST") rather than the ISO 8601 "Z" suffix.
 const puppetCaTimeLayout = "2006-01-02T15:04:05MST"
 
-func (t *PuppetCaTime) UnmarshalJSON(data []byte) error {
-	// Puppet CA returns time in a non-standard format, so we need to parse it manually ...
+func (t *PuppetTime) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}
 
-	parsedTime, err := time.Parse(puppetCaTimeLayout, s)
+	// golang-puppet-ca and future implementations use ISO 8601 / RFC 3339 ("Z" or "+HH:MM");
+	// OpenVox Server / Puppet Server / OpenVoxDB / PuppetDB (Clojure) use a named timezone
+	// abbreviation. Try the standard format first, then fall back.
+	parsedTime, err := time.Parse(time.RFC3339, s)
 	if err != nil {
-		return err
+		parsedTime, err = time.Parse(puppetCaTimeLayout, s)
+		if err != nil {
+			return fmt.Errorf("cannot parse %q as a Puppet CA timestamp: %w", s, err)
+		}
 	}
 
 	t.Time = parsedTime
 	return nil
 }
 
-func (t PuppetCaTime) MarshalJSON() ([]byte, error) {
-	// ... but when marshalling we want to use the standard RFC3339 format.
+func (t PuppetTime) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Format(time.RFC3339))
 }

--- a/model/node.go
+++ b/model/node.go
@@ -1,16 +1,14 @@
 package model
 
-import "time"
-
 type Node struct {
 	// Fields in OpenVoxDB nodes response format:
 	// https://github.com/OpenVoxProject/openvoxdb/blob/8.12.1/documentation/api/query/v4/nodes.markdown#response-format
-	Name                    string     `json:"certname"`
-	Deactivated             *time.Time `json:"deactivated"`
-	Expired                 *time.Time `json:"expired"`
-	CatalogTimestamp        *time.Time `json:"catalog_timestamp"`
-	FactsTimestamp          *time.Time `json:"facts_timestamp"`
-	ReportTimestamp         *time.Time `json:"report_timestamp"`
+	Name                    string      `json:"certname"`
+	Deactivated             *PuppetTime `json:"deactivated"`
+	Expired                 *PuppetTime `json:"expired"`
+	CatalogTimestamp        *PuppetTime `json:"catalog_timestamp"`
+	FactsTimestamp          *PuppetTime `json:"facts_timestamp"`
+	ReportTimestamp         *PuppetTime `json:"report_timestamp"`
 	CatalogEnvironment      *string    `json:"catalog_environment"`
 	FactsEnvironment        *string    `json:"facts_environment"`
 	ReportEnvironment       *string    `json:"report_environment"`


### PR DESCRIPTION
OpenVox Server, Puppet Server, OpenVoxDB, and PuppetDB (all Clojure-based) return timestamps in a non-standard format with a named timezone abbreviation (e.g. "2026-05-06T17:38:05UTC"). The golang-puppet-ca implementation (https://github.com/trevor-vaughan/golang-puppet-ca) uses standard ISO 8601 / RFC 3339 with a "Z" suffix, I expect future implementations to do the same.

Introduce PuppetTime, which tries RFC 3339 first and falls back to the named-timezone layout. Replace PuppetCaTime with a type alias for PuppetTime for compatibility, and update the Node model to use *PuppetTime instead of *time.Time for its timestamp fields.

Also add PuppetSerialNumber to handle certificate serial numbers that arrive as either a JSON number (OpenVox Server / Puppet Server) or a JSON string (golang-puppet-ca and expected future implementations), always re-marshalling as a string (matching what the frontend expects).

Full disclosure: I used Claude Code to author this PR.