### PR TITLE
Add an export as CSV functionnality

### DIFF
--- a/ui/src/components/NodeTable.vue
+++ b/ui/src/components/NodeTable.vue
@@ -7,6 +7,7 @@ import { type PropType } from 'vue';
 import { type PuppetNodeWithEventCount } from 'src/puppet/models/puppet-node';
 import { emptyPagination } from 'src/helper/objects';
 import StatusButton from 'components/StatusButton.vue';
+import { exportQTableAsCsv } from 'src/helper/csv';
 
 const { t } = useI18n();
 
@@ -23,20 +24,34 @@ const unreportedDate = defineModel('unreported_date', {
   required: false,
 });
 
-function getStatus(node: PuppetNodeWithEventCount) {
+function getStatus(node: PuppetNodeWithEventCount): string {
   if (!node.report_timestamp) return 'unreported';
 
-  if (unreportedDate.value && unreportedDate.value > new Date(node.report_timestamp)) {
+  if (
+    unreportedDate.value &&
+    unreportedDate.value > new Date(node.report_timestamp)
+  ) {
     return 'unreported';
   }
 
   return node.latest_report_status;
 }
 
+function getEventAsString(node: PuppetNodeWithEventCount): string {
+  const eventElements = [
+    getStatus(node),
+    `${node.events.failures} failures`,
+    `${node.events.successes} successes`,
+    `${node.events.skips} skips`,
+    `${node.events.noops} noops`,
+  ];
+  return eventElements.join(' | ');
+}
+
 const columns: QTableColumn[] = [
   {
     name: 'events',
-    field: 'events',
+    field: (row) => getEventAsString(row),
     label: t('LABEL_EVENT', 2),
     align: 'left',
   },
@@ -79,12 +94,26 @@ const columns: QTableColumn[] = [
       </q-tr>
     </template>
 
+    <template v-slot:top-right>
+      <q-btn
+        color="primary"
+        icon-right="archive"
+        :label="$t('EXPORT_AS_CSV')"
+        no-caps
+        @click="() => exportQTableAsCsv(nodes, columns, t)"
+      />
+    </template>
+
     <template v-slot:body="props">
       <q-tr :props="props">
         <q-td v-for="col in props.cols" :key="col.name" :props="props">
           <div v-if="col.name == 'events'" class="row">
-            <StatusButton v-if="props.row.latest_report_status" :status="getStatus(props.row)"
-              :hash="props.row.latest_report_hash" :certname="props.row.certname" />
+            <StatusButton
+              v-if="props.row.latest_report_status"
+              :status="getStatus(props.row)"
+              :hash="props.row.latest_report_hash"
+              :certname="props.row.certname"
+            />
             <EventCountBlock :event_count="props.row.eventsMapped" />
           </div>
           <NodeLink v-else-if="col.name == 'certname'" :certname="col.value" />

--- a/ui/src/components/QueryExecuter.vue
+++ b/ui/src/components/QueryExecuter.vue
@@ -15,6 +15,7 @@ import {
 } from 'src/helper/functions';
 import { type AxiosError } from 'axios';
 import { type ErrorResponse } from 'src/client/models';
+import { exportQTableAsCsv } from 'src/helper/csv';
 
 interface SelectedItem {
   name: string;
@@ -22,7 +23,7 @@ interface SelectedItem {
 }
 
 const { t } = useI18n();
-const data = ref<PuppetQueryResult<unknown[]>>();
+const data = ref<PuppetQueryResult<object[]>>();
 const query = defineModel('query', { type: String });
 const isLoading = ref(false);
 const tab = ref('data');
@@ -68,7 +69,7 @@ function executeQuery() {
   console.log('executing: ', queryWithParams);
   if (!queryWithParams) return;
   isLoading.value = true;
-  void Backend.getRawQueryResult<unknown[]>(queryWithParams, true)
+  void Backend.getRawQueryResult<object[]>(queryWithParams, true)
     .then((result) => {
       if (result.status === 200) {
         data.value = result.data.Data;
@@ -111,6 +112,18 @@ function copyTimestampToClipboard(timestamp: Date) {
         message: t('NOTIFICATION_COPY_TO_CLIPBOARD_FAILED'),
       });
     });
+}
+
+function exportQueriedTableAsCsv(
+  data: PuppetQueryResult<object[]> | undefined,
+) {
+  if (!data) return;
+  const columns = Object.keys(data.Data[0] ?? {}).map((key) => ({
+    name: key,
+    label: key,
+    field: key,
+  }));
+  exportQTableAsCsv(data.Data, columns, t);
 }
 </script>
 
@@ -206,6 +219,15 @@ function copyTimestampToClipboard(timestamp: Date) {
       <q-tab-panels v-model="tab" animated>
         <q-tab-panel v-if="data.Data" name="data" class="q-pa-none">
           <q-table :rows="data.Data" flat>
+            <template v-slot:top-right v-if="data.Data.length > 0">
+              <q-btn
+                color="primary"
+                icon-right="download"
+                :label="$t('EXPORT_AS_CSV')"
+                no-caps
+                @click="() => exportQueriedTableAsCsv(data)"
+              />
+            </template>
             <template v-slot:body="props">
               <q-tr :props="props">
                 <q-td v-for="col in props.cols" :key="col.name" :props="props">

--- a/ui/src/helper/csv.ts
+++ b/ui/src/helper/csv.ts
@@ -1,0 +1,73 @@
+import { exportFile, Notify, type QTableColumn } from 'quasar';
+import type { ComposerTranslation } from 'vue-i18n';
+
+interface CSVColumns {
+  field?: string | ((row: Record<string, unknown>) => string);
+  label: string;
+  name?: string;
+}
+
+/**
+ * Encode an array of objects into a CSV string.
+ */
+function csvEncoder(
+  objects: Record<string, unknown>[],
+  csvColumns: CSVColumns[],
+): string {
+  const separator = ';';
+  const columns = csvColumns.map((col) => col.label);
+  const csvRows = objects.map((obj) => {
+    const rowElements = csvColumns.map((col) => {
+      if (typeof col.field === 'function') {
+        const val = col.field(obj);
+        if (val !== undefined) {
+          return val;
+        }
+      }
+      const key = (col.field as string) ?? col.name;
+      return Object.hasOwn(obj, key) ? obj[key] : '';
+    });
+    return rowElements.join(separator);
+  });
+  return [
+    columns.join(separator),
+    csvRows.join('\r\n'),
+  ].join('\r\n');
+}
+
+/**
+ * Export an array of objects as CSV.
+ */
+function exportAsCsv(objects: Record<string, unknown>[], csvColumns: CSVColumns[]): boolean|Error {
+  const content = csvEncoder(objects, csvColumns);
+  const status = exportFile('table-export.csv', content, 'text/csv');
+  if (status !== true) {
+    console.error('Error during file download', status);
+  }
+  return status;
+}
+
+
+/**
+ * Util function to export a QTable as CSV.
+ * Typesafe and notify on error.
+ */
+export function exportQTableAsCsv(rows: object[], columns: QTableColumn[], t: ComposerTranslation): boolean|Error {
+  const objects = rows.map((node) => {
+    return Object.entries(node).reduce(
+      (acc, [key, value]) => {
+        acc[key] = value;
+        return acc;
+      },
+      {} as Record<string, unknown>,
+    );
+  });
+  const status = exportAsCsv(objects, columns);
+  if (status !== true) {
+    Notify.create({
+      type:'negative',
+      message: t('ERROR_CSV_EXPORT'),
+    });
+  }
+  return status;
+}

--- a/ui/src/i18n/langs/de-DE.json
+++ b/ui/src/i18n/langs/de-DE.json
@@ -88,5 +88,7 @@
   "LABEL_OFF": "Aus",
   "LABEL_LAST_REFRESH": "Letzte Aktualisierung",
   "LABEL_AUTO_REFRESH_OFF": "Automatische Aktualisierung aus",
-  "LABEL_REFRESH": "Aktualisieren"
+  "LABEL_REFRESH": "Aktualisieren",
+  "EXPORT_AS_CSV": "Als CSV exportieren",
+  "ERROR_CSV_EXPORT": "Fehler beim Export als CSV"
 }

--- a/ui/src/i18n/langs/en-US.json
+++ b/ui/src/i18n/langs/en-US.json
@@ -88,5 +88,7 @@
   "LABEL_OFF": "Off",
   "LABEL_LAST_REFRESH": "Last refresh",
   "LABEL_AUTO_REFRESH_OFF": "Auto refresh off",
-  "LABEL_REFRESH": "Refresh"
+  "LABEL_REFRESH": "Refresh",
+  "EXPORT_AS_CSV": "Export as CSV",
+  "ERROR_CSV_EXPORT": "Error while exporting as CSV"
 }

--- a/ui/src/pages/report/ReportOverviewPage.vue
+++ b/ui/src/pages/report/ReportOverviewPage.vue
@@ -13,6 +13,7 @@ import {
 import { useSettingsStore } from 'stores/settings';
 import { useRoute, useRouter } from 'vue-router';
 import RefreshIntervalSelect from 'components/RefreshIntervalSelect.vue';
+import { exportQTableAsCsv } from 'src/helper/csv';
 
 interface PaginationInterface {
   sortBy?: string | null;
@@ -62,10 +63,11 @@ const pagination = ref<PaginationInterface>({
   rowsNumber: 10,
 });
 
+
 const columns: QTableColumn[] = [
   {
     name: 'end_time',
-    field: 'endTimeFormatted',
+    field: 'end_time',
     label: t('LABEL_END_TIME'),
     align: 'left',
     sortable: true,
@@ -343,10 +345,19 @@ onMounted(() => {
       :title="$t('LABEL_REPORT', 2)"
     >
       <template v-slot:top-right>
-        <RefreshIntervalSelect @refresh="loadReports" class="q-mr-md" />
-        <q-btn icon="refresh" color="secondary" @click="loadReports">
-          <q-tooltip>{{ $t('LABEL_REFRESH') }}</q-tooltip>
-        </q-btn>
+          <div class="row q-gutter-sm">
+            <RefreshIntervalSelect @refresh="loadReports" />
+            <q-btn icon="refresh" color="secondary" @click="loadReports">
+              <q-tooltip>{{ $t('LABEL_REFRESH') }}</q-tooltip>
+            </q-btn>
+            <q-btn
+              color="primary"
+              icon-right="archive"
+              :label="$t('EXPORT_AS_CSV')"
+              no-caps
+              @click="() => exportQTableAsCsv(reports, columns, t)"
+            />
+          </div>
       </template>
       <template v-slot:body="props">
         <q-tr :props="props">

--- a/ui/src/pages/views/PredefinedViewResultPage.vue
+++ b/ui/src/pages/views/PredefinedViewResultPage.vue
@@ -7,11 +7,14 @@ import NodeLink from 'components/NodeLink.vue';
 import { getOsNameFromOsFact } from 'src/helper/functions';
 import { type QTableColumn, type QTableProps } from 'quasar';
 import { useSettingsStore } from 'stores/settings';
+import { exportQTableAsCsv } from 'src/helper/csv';
+import { useI18n } from 'vue-i18n';
 
 type Pagination = Parameters<NonNullable<QTableProps['onUpdate:pagination']>>[0];
 
 const DEFAULT_ROWS_PER_PAGE = 20;
 
+const { t } = useI18n();
 const route = useRoute();
 const viewName = computed(() => {
   return route.params.viewName as string;
@@ -23,11 +26,31 @@ const pagination = ref<NonNullable<QTableProps['pagination']>>({
 });
 const settings = useSettingsStore();
 
+type ViewResultQTableRow = {
+  os?: { name: string };
+  trusted?: { certname: string; };
+  networking?: { ip: string };
+  [key: string]: unknown;
+};
+
+const tryGetFieldFromFacts = (fact: string): ((row: ViewResultQTableRow) => string | undefined)|string => {
+  if (fact === 'os') {
+    return (row) => row?.os?.name;
+  }
+  if (fact === 'trusted') {
+    return (row) => row?.trusted?.certname;
+  }
+  if (fact === 'networking.ip') {
+    return (row) => row?.networking?.ip;
+  }
+  return fact;
+}
+
 const columns = computed((): QTableColumn[] => {
   return viewResult.value!.View.Facts.map((s) => {
     return {
       name: s.Name,
-      field: s.Fact,
+      field: tryGetFieldFromFacts(s.Fact),
       label: s.Name,
       format: (val: string, row: never) => getProperty(row, s.Fact),
       sortable: true,
@@ -139,6 +162,15 @@ onMounted(() => {
         :pagination="pagination"
         @update:pagination="paginationUpdate"
       >
+        <template v-slot:top-right>
+          <q-btn
+            color="primary"
+            icon-right="archive"
+            :label="$t('EXPORT_AS_CSV')"
+            no-caps
+            @click="() => exportQTableAsCsv((viewResult?.Data as object[] ?? []), columns, t)"
+          />
+        </template>
         <template v-slot:body="props">
           <q-tr :props="props">
             <q-td v-for="col in props.cols" :key="col.name" :props="props">


### PR DESCRIPTION
Fix #159 

Add export as CSV on tables.

I added a `helper/csv.ts` file to encode object/columns to csv content and export it with `exportFile` from `Quasar`.
Components can now call `exportQTableAsCsv` with data and columns to export the displayed content as CSV.

I had to adjust a few `field` properties to not have values like "[Object object]" exported.

It works well on my dataset. I hope it works well everywhere.
Let me know if I have to adjust something. I've less time this week to work on it.